### PR TITLE
@plaiceholder/next: Add Sharp to Webpack Externals

### DIFF
--- a/examples/next/next.config.js
+++ b/examples/next/next.config.js
@@ -4,13 +4,6 @@ module.exports = withPlaiceholder({
   images: {
     domains: ["images.unsplash.com"],
   },
-  webpack: (config) => {
-    config.externals.push({
-      sharp: "commonjs sharp",
-    });
-
-    return config;
-  },
   future: {
     webpack5: true,
   },

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -1,5 +1,17 @@
-export const withPlaiceholder = (config) => {
+export const withPlaiceholder = (nextConfig) => {
   require("sharp");
 
-  return config;
+  return Object.assign({}, nextConfig, {
+    webpack(config, options) {
+      config.externals.push({
+        sharp: "commonjs sharp",
+      });
+
+      if (typeof nextConfig?.webpack === "function") {
+        return nextConfig.webpack(config, options);
+      }
+
+      return config;
+    },
+  });
 };


### PR DESCRIPTION
Extends Next.js' webpack config to prevent Vercel deployment error
(See https://github.com/lovell/sharp/issues/2350)