### PR TITLE
feat(support nextjs 12): add Nextjs12 Support

### DIFF
--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -28,7 +28,7 @@
     "dev": "yarn build -- watch"
   },
   "peerDependencies": {
-    "next": ">= 10.0.0",
+    "next": ">= 12.0.0",
     "sharp": ">= 0.26.2"
   },
   "devDependencies": {

--- a/packages/next/src/index.ts
+++ b/packages/next/src/index.ts
@@ -3,7 +3,7 @@ export const withPlaiceholder = (nextConfig) => {
 
   return Object.assign({}, nextConfig, {
     webpack(config, options) {
-      config.externals.push({
+      config.externals = Object.assign(config.externals, {
         sharp: "commonjs sharp",
       });
 


### PR DESCRIPTION
This change fixes the webpack config to support NextJS 12

BREAKING CHANGE: Requires NextJS 12

<!-- Thank you for contributing! -->

### Description
NextJS 12 support

### Additional context
With NextJS 12 you will run in this error
```
TypeError: config.externals.push is not a function
```

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
