### PR TITLE
feat: expose image processing params to api for end user to customize

### DIFF
--- a/packages/plaiceholder/src/get-image.ts
+++ b/packages/plaiceholder/src/get-image.ts
@@ -119,6 +119,10 @@ const loadImage: ILoadImage = async (imagePath) => {
 
 interface IOptimizeImageOptions {
   size?: number;
+  saturation?: number;
+  brightness?: number;
+  normalise?: boolean;
+  removeAlpha?: boolean;
 }
 interface IOptimizeImageReturn
   extends Record<
@@ -154,12 +158,39 @@ const optimizeImage: IOptimizeImage = async (src, options = { size: 4 }) => {
     fit: "inside",
   });
 
-  const getOptimizedForBase64 = pipeline
-    .clone()
-    .normalise()
-    .modulate({ saturation: 1.2, brightness: 1 })
-    .removeAlpha()
-    .toBuffer({ resolveWithObject: true });
+  let saturation = 1.2;
+  if (options?.saturation !== undefined) {
+    saturation = options?.saturation;
+  }
+
+  let brightness = 1;
+  if (options?.brightness !== undefined) {
+    brightness = options?.brightness;
+  }
+
+  let normalise = true;
+  if (options?.normalise !== undefined) {
+    normalise = options?.normalise;
+  }
+
+  let removeAlpha = true;
+  if (options?.removeAlpha !== undefined) {
+    removeAlpha = options?.removeAlpha;
+  }
+
+  const configBase64 = pipeline.clone().modulate({ saturation, brightness });
+
+  if (normalise) {
+    configBase64.normalise();
+  }
+
+  if (removeAlpha) {
+    configBase64.removeAlpha();
+  }
+
+  const getOptimizedForBase64 = configBase64.toBuffer({
+    resolveWithObject: true,
+  });
 
   const getOptimizedForBlurhash = pipeline
     .clone()


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Allows the end user to specify which processing params they would like to apply to their base64 placeholder images.

e.g.
```js
const { base64, img } = await getPlaiceholder(
  "https://images.unsplash.com/photo-1621961458348-f013d219b50c?auto=format&fit=crop&w=2850&q=80",
  {
    size: 10,
    saturation: 1,
    brightness: 1,
    normalise: false,
    removeAlpha: false,
  }
);
```
### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
closes  #171
---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [X] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
