### PR TITLE
fix: Fix CSS if the source contains transparency

### DIFF
--- a/packages/plaiceholder/src/css.ts
+++ b/packages/plaiceholder/src/css.ts
@@ -2,8 +2,9 @@ import type { IGetImageReturn } from "./get-image";
 
 type TGetImageReturnCSS = IGetImageReturn["optimizedForCSS"];
 
-const rgb = (channels: (number | string)[]) =>
-  `rgb${channels.length === 4 ? "a" : ""}(${channels.join(",")})`;
+const rgb = (channels: number[]) => `rgb(${channels.slice(0, 3).join(",")})`;
+const rgba = (channels: number[]) =>
+  `rgba(${channels.slice(0, 3).join(",")},${(channels[3] / 255).toFixed(3)})`;
 
 export interface IGetCSSOptions extends TGetImageReturnCSS {}
 export interface IGetCSSReturn
@@ -21,7 +22,9 @@ export interface IGetCSS {
 
 export const getCSS: IGetCSS = ({ info, rows }) => {
   const linearGradients = rows.map((row) => {
-    const pixels = row.map((pixel) => rgb(pixel));
+    const pixels = row.map((pixel) =>
+      pixel.length === 4 ? rgba(pixel) : rgb(pixel)
+    );
 
     const gradient = pixels
       .map((pixel, i) => {


### PR DESCRIPTION
Fixes a bug in the CSS logic if the source contains transparency

<!-- Thank you for contributing! -->

### Description

#### Before
![before](https://user-images.githubusercontent.com/1972314/167236486-137270da-c621-4cbd-9738-b908f191d843.png)

#### After

![after](https://user-images.githubusercontent.com/1972314/167236428-a0993350-67cc-415a-9fc9-9ff203e21767.png)

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
