### PR TITLE
fix: exclude undefined from SharpModulateOptions

### DIFF
--- a/packages/plaiceholder/src/get-image.ts
+++ b/packages/plaiceholder/src/get-image.ts
@@ -121,7 +121,7 @@ const loadImage: ILoadImage = async (imagePath, options) => {
    =========================================== */
 
 type SharpFormatOptions = Parameters<Sharp["toFormat"]>;
-type SharpModulateOptions = Parameters<Sharp["modulate"]>[0];
+type SharpModulateOptions = NonNullable<Parameters<Sharp["modulate"]>[0]>;
 
 interface IOptimizeImageOptions extends SharpModulateOptions {
   size?: number;


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
A project using the strict null checks TS compiler flag currently cannot be built since the first parameter of  `Sharp["modulate"]` is optional. As `IOptimizeImageOptions`  cannot extend undefined this throws on build. This PR excludes `undefined`  from `SharpModulateOptions`.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md).
- [x] Follow the [Style Guide](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md#style-guide).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
