### PR TITLE
Fix node example

### DIFF
--- a/docs/pages/docs/upgrading-to-3.mdx
+++ b/docs/pages/docs/upgrading-to-3.mdx
@@ -45,8 +45,7 @@ Ensure all `plaiceholder` and `@plaiceholder/*` packages are set to at least `3.
    import fs from "node:fs/promises";
 
    const getImage = async (src: string) => {
-     const file = await fs.readFile(path.join("./public", src));
-     const buffer = await fs.readFile(file);
+     const buffer = await fs.readFile(path.join("./public", src));
 
      const {
        metadata: { height, width },


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

I think the two `readFile` calls in the node example was a mistype, you only need one to pass the buffer and trying to call readFile on the result from the first call throws an error. 


### What is the purpose of this pull request?

<!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md).
- [ ] Follow the [Style Guide](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md#style-guide).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
