### PR TITLE
Fix broken links

### DIFF
--- a/docs/pages/docs/plugins/next.mdx
+++ b/docs/pages/docs/plugins/next.mdx
@@ -12,7 +12,7 @@ An **essential** plugin for Next.js, ensuring that all Plaiceholder functions st
 
 ## Installation
 
-1. Add the package alongside your [existing `plaiceholder` installation](/getting-started):
+1. Add the package alongside your [existing `plaiceholder` installation](/docs/getting-started):
 
    ```sh
    npm install @plaiceholder/next
@@ -43,4 +43,4 @@ An **essential** plugin for Next.js, ensuring that all Plaiceholder functions st
 
 ## Usage
 
-…and that's it! Use Next.js and [plaiceholder](/usage) as you would expect.
+…and that's it! Use Next.js and [plaiceholder](/docs/usage) as you would expect.

--- a/docs/pages/docs/plugins/tailwind.mdx
+++ b/docs/pages/docs/plugins/tailwind.mdx
@@ -10,7 +10,7 @@ import { Callout, Tab, Tabs } from "nextra-theme-docs";
 
 ## Installation
 
-1. Install the package alongside your existing [`tailwindcss`](https://tailwindcss.com/docs/installation) and [`plaiceholder`](/getting-started) installation:
+1. Install the package alongside your existing [`tailwindcss`](https://tailwindcss.com/docs/installation) and [`plaiceholder`](/docs/getting-started) installation:
 
    ```sh
    npm install @plaiceholder/tailwindcss


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

There are some broken links which are leading to 404 page in documentation specifically tailwind and next js guide. As there is no /docs before link it's broken. I added it.

### Additional context

No

### What is the purpose of this pull request?

- [ ] Bug fix
- [ ] New Feature
- [X] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Read the [Contributing Guidelines](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md).
- [X] Follow the [Style Guide](https://github.com/joe-bell/plaiceholder/blob/main/CONTRIBUTING.md#style-guide).
- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
